### PR TITLE
Store settings in user-specific config directory

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -2,6 +2,7 @@
 from dataclasses import dataclass
 from pathlib import Path
 import json
+import os
 
 
 def _parse_ratio(value):
@@ -34,7 +35,9 @@ DEFAULTS = {
     'excelMapping': {'klasse': 'A', 'nachname': 'B', 'vorname': 'C', 'schuelerId': 'D', 'fotografiert': 'E', 'aufnahmedatum': 'F'},
 }
 
-CONFIG_PATH = Path('settings.json')
+CONFIG_DIR = Path(os.getenv("APPDATA", Path.home())) / "LegicCardCreator"
+CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+CONFIG_PATH = CONFIG_DIR / "settings.json"
 
 @dataclass
 class Settings:


### PR DESCRIPTION
## Summary
- Store `settings.json` under `APPDATA/LegicCardCreator` (or home fallback) so settings are written to a user-writable location

## Testing
- `pytest`
- `pyinstaller --onefile --windowed -n LegicCardCreator app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6899adf3bcc8832c928bb3173d3da93a