### PR TITLE
Refactor settings to Pydantic models

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -1,28 +1,28 @@
 # app/core/config/settings.py
-from dataclasses import dataclass
+"""Configuration management using Pydantic models."""
+
 from pathlib import Path
 import json
 import os
+from typing import Tuple, Optional
 
+from pydantic import BaseModel, Field, field_validator, ConfigDict
 
-def _parse_ratio(value):
-    if isinstance(value, str) and ':' in value:
-        a, b = value.split(':', 1)
-        if a.isdigit() and b.isdigit():
-            return int(a), int(b)
-    if isinstance(value, (list, tuple)) and len(value) == 2:
-        return int(value[0]), int(value[1])
-    return (3, 4)
 
 DEFAULTS = {
     'ausgabeBasisPfad': 'output',
     'missedPath': 'Verpasste_Termine.xlsx',
-    'bild': {'breite': 1200, 'hoehe': 1600, 'qualitaet': 90, 'seitenverhaeltnis': '3:4'},
+    'bild': {
+        'breite': 1200,
+        'hoehe': 1600,
+        'qualitaet': 90,
+        'seitenverhaeltnis': '3:4',
+    },
     'overlay': {
         'drittellinien': True,
         'horizonte': False,
         'deckkraft': 0.3,
-        'image': ''
+        'image': '',
     },
     'kamera': {
         'backend': 'opencv',
@@ -47,40 +47,96 @@ CONFIG_DIR = Path(os.getenv("APPDATA", Path.home())) / "LegicCardCreator"
 CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 CONFIG_PATH = CONFIG_DIR / "settings.json"
 
-@dataclass
-class Settings:
-    ausgabeBasisPfad: Path
-    missedPath: Path
-    bild: dict
-    overlay: dict
-    kamera: dict
-    zip: dict
-    copyright: dict
-    excelMapping: dict
 
-    @staticmethod
-    def load(path: Path = CONFIG_PATH) -> 'Settings':
+class BildSettings(BaseModel):
+    breite: int
+    hoehe: int
+    qualitaet: int
+    seitenverhaeltnis: Tuple[int, int] = (3, 4)
+
+    @field_validator('seitenverhaeltnis', mode='before')
+    @classmethod
+    def parse_ratio(cls, v):
+        if isinstance(v, str) and ':' in v:
+            a, b = v.split(':', 1)
+            if a.isdigit() and b.isdigit():
+                return int(a), int(b)
+        if isinstance(v, (list, tuple)) and len(v) == 2:
+            return int(v[0]), int(v[1])
+        raise ValueError('Invalid ratio format')
+
+
+class OverlaySettings(BaseModel):
+    drittellinien: bool = True
+    horizonte: bool = False
+    deckkraft: float = 0.3
+    image: Optional[Path] = Field(default=None)
+
+    @field_validator('image', mode='before')
+    @classmethod
+    def check_image(cls, v):
+        if not v:
+            return None
+        p = Path(v)
+        if not p.exists():
+            raise ValueError(f'Overlay image not found: {v}')
+        return p
+
+
+class KameraSettings(BaseModel):
+    backend: str = 'opencv'
+    liveviewFpsZiel: int = 20
+    format: str = 'JPEG'
+    timeoutMs: int = 5000
+
+
+class ZipSettings(BaseModel):
+    maxAnzahl: Optional[int] = None
+    maxGroesseMB: Optional[int] = None
+
+
+class CopyrightSettings(BaseModel):
+    artist: str = ''
+    copyright: str = ''
+
+
+class ExcelMapping(BaseModel):
+    klasse: str = 'A'
+    nachname: str = 'B'
+    vorname: str = 'C'
+    schuelerId: str = 'D'
+    fotografiert: str = 'E'
+    aufnahmedatum: str = 'F'
+    grund: str = 'G'
+
+
+class Settings(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
+    ausgabeBasisPfad: Path = Field(default_factory=lambda: Path('output'))
+    missedPath: Path = Field(default_factory=lambda: Path('Verpasste_Termine.xlsx'))
+    bild: BildSettings = Field(default_factory=BildSettings)
+    overlay: OverlaySettings = Field(default_factory=OverlaySettings)
+    kamera: KameraSettings = Field(default_factory=KameraSettings)
+    zip: ZipSettings = Field(default_factory=ZipSettings)
+    copyright: CopyrightSettings = Field(default_factory=CopyrightSettings)
+    excelMapping: ExcelMapping = Field(default_factory=ExcelMapping)
+
+    @classmethod
+    def load(cls, path: Path = CONFIG_PATH) -> 'Settings':
         if path.exists():
             data = json.loads(path.read_text(encoding='utf-8'))
         else:
             data = DEFAULTS
             path.write_text(json.dumps(data, indent=2), encoding='utf-8')
-        data['ausgabeBasisPfad'] = Path(data['ausgabeBasisPfad'])
-        data['missedPath'] = Path(data.get('missedPath', 'Verpasste_Termine.xlsx'))
-        data['bild']['seitenverhaeltnis'] = _parse_ratio(data['bild'].get('seitenverhaeltnis', '3:4'))
-        if data.get('overlay') and 'image' in data['overlay']:
-            img = data['overlay']['image']
-            data['overlay']['image'] = str(img) if img else ''
-        else:
-            data.setdefault('overlay', {}).setdefault('image', '')
-        return Settings(**data)
+        return cls.model_validate(data)
 
     def save(self, path: Path = CONFIG_PATH) -> None:
-        data = self.__dict__.copy()
+        data = self.model_dump()
         data['ausgabeBasisPfad'] = str(data['ausgabeBasisPfad'])
         data['missedPath'] = str(data['missedPath'])
-        ratio = data['bild'].get('seitenverhaeltnis', (3, 4))
-        if isinstance(ratio, tuple):
-            data['bild']['seitenverhaeltnis'] = f"{ratio[0]}:{ratio[1]}"
-        data['overlay']['image'] = data['overlay'].get('image', '')
+        ratio = data['bild']['seitenverhaeltnis']
+        data['bild']['seitenverhaeltnis'] = f"{ratio[0]}:{ratio[1]}"
+        img = data['overlay'].get('image')
+        data['overlay']['image'] = str(img) if img else ''
         path.write_text(json.dumps(data, indent=2), encoding='utf-8')

--- a/app/main.py
+++ b/app/main.py
@@ -3,11 +3,16 @@ import sys
 from PySide6 import QtWidgets, QtGui
 from pathlib import Path
 from app.core.config.settings import Settings
+from pydantic import ValidationError
 from app.core.util.logging import setup_logging
 from app.ui.main_window import MainWindow
 
 def main():
-    settings = Settings.load()
+    try:
+        settings = Settings.load()
+    except ValidationError as e:
+        print(f"Fehler in der Konfiguration: {e}", file=sys.stderr)
+        return 1
     setup_logging(Path('logs'))
     app = QtWidgets.QApplication(sys.argv)
     app.setStyle("Fusion")

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -26,7 +26,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.camera.start_liveview()
 
     def _init_camera(self):
-        backend = self.settings.kamera.get('backend', 'opencv')
+        backend = self.settings.kamera.backend
         cam = None
         if backend == 'gphoto2' and QtCore.QStandardPaths.findExecutable('gphoto2'):
             cam = GPhoto2Camera()
@@ -89,9 +89,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # right preview
         from .widgets.live_view_widget import LiveViewWidget
-        fps = self.settings.kamera.get('liveviewFpsZiel', 20)
+        fps = self.settings.kamera.liveviewFpsZiel
         self.preview = LiveViewWidget(self.camera, fps)
-        self.preview.set_overlay_image(self.settings.overlay.get('image'))
+        self.preview.set_overlay_image(self.settings.overlay.image)
         preview_layout = QtWidgets.QVBoxLayout()
         preview_layout.setSpacing(10)
         name_layout = QtWidgets.QHBoxLayout()
@@ -140,7 +140,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if not path:
             return
         try:
-            self.reader = ExcelReader(Path(path), self.settings.excelMapping)
+            self.reader = ExcelReader(Path(path), self.settings.excelMapping.model_dump())
         except Exception as e:
             QtWidgets.QMessageBox.critical(self, 'Excel', str(e))
             return
@@ -403,17 +403,17 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def open_settings(self):
         dlg = SettingsDialog(self.settings, self)
-        before_backend = self.settings.kamera.get('backend')
-        before_overlay = self.settings.overlay.get('image')
+        before_backend = self.settings.kamera.backend
+        before_overlay = self.settings.overlay.image
         if dlg.exec() == QtWidgets.QDialog.Accepted:
-            if self.settings.kamera.get('backend') != before_backend:
+            if self.settings.kamera.backend != before_backend:
                 self.camera.stop_liveview()
                 self.camera = self._init_camera()
                 if hasattr(self.camera, 'start_liveview'):
                     self.camera.start_liveview()
                 self.preview.set_camera(self.camera)
-            if self.settings.overlay.get('image') != before_overlay:
-                self.preview.set_overlay_image(self.settings.overlay.get('image'))
+            if self.settings.overlay.image != before_overlay:
+                self.preview.set_overlay_image(self.settings.overlay.image)
         self._update_buttons()
 
     def _update_buttons(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Pillow
 opencv-python-headless
 pytest
 psutil
+pydantic

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,16 +1,28 @@
 """Tests for configuration settings management."""
 
 from pathlib import Path
+import json
+import pytest
+from pydantic import ValidationError
 
-from app.core.config.settings import Settings, DEFAULTS
+from app.core.config.settings import (
+    Settings,
+    DEFAULTS,
+    BildSettings,
+    OverlaySettings,
+    KameraSettings,
+    ZipSettings,
+    CopyrightSettings,
+    ExcelMapping,
+)
 
 
 def test_load_creates_file_with_defaults(tmp_path):
     cfg = tmp_path / "settings.json"
     settings = Settings.load(cfg)
     assert cfg.exists()
-    assert settings.bild["seitenverhaeltnis"] == (3, 4)
-    assert settings.overlay.get("image") == ""
+    assert settings.bild.seitenverhaeltnis == (3, 4)
+    assert settings.overlay.image is None
 
 
 def test_save_and_load_roundtrip(tmp_path):
@@ -18,14 +30,24 @@ def test_save_and_load_roundtrip(tmp_path):
     s = Settings(
         ausgabeBasisPfad=tmp_path,
         missedPath=tmp_path / "missed.xlsx",
-        bild={"breite": 800, "hoehe": 600, "qualitaet": 80, "seitenverhaeltnis": (4, 3)},
-        overlay={"drittellinien": True, "horizonte": False, "deckkraft": 0.3, "image": ""},
-        kamera={"backend": "opencv", "liveviewFpsZiel": 20, "format": "JPEG", "timeoutMs": 5000},
-        zip={"maxAnzahl": None, "maxGroesseMB": None},
-        copyright={"artist": "", "copyright": ""},
-        excelMapping=DEFAULTS["excelMapping"],
+        bild=BildSettings(breite=800, hoehe=600, qualitaet=80, seitenverhaeltnis=(4, 3)),
+        overlay=OverlaySettings(drittellinien=True, horizonte=False, deckkraft=0.3, image=None),
+        kamera=KameraSettings(backend="opencv", liveviewFpsZiel=20, format="JPEG", timeoutMs=5000),
+        zip=ZipSettings(maxAnzahl=None, maxGroesseMB=None),
+        copyright=CopyrightSettings(artist="", copyright=""),
+        excelMapping=ExcelMapping(**DEFAULTS["excelMapping"]),
     )
     s.save(cfg)
     loaded = Settings.load(cfg)
-    assert loaded.bild["seitenverhaeltnis"] == (4, 3)
+    assert loaded.bild.seitenverhaeltnis == (4, 3)
     assert loaded.ausgabeBasisPfad == tmp_path
+
+
+def test_overlay_path_validation(tmp_path):
+    cfg = tmp_path / "settings.json"
+    data = DEFAULTS.copy()
+    data["overlay"] = data["overlay"].copy()
+    data["overlay"]["image"] = str(tmp_path / "missing.png")
+    cfg.write_text(json.dumps(data), encoding="utf-8")
+    with pytest.raises(ValidationError):
+        Settings.load(cfg)


### PR DESCRIPTION
## Summary
- Replace dataclass settings with Pydantic models providing type hints and validation for ratios and overlay image path
- Serialize settings via `model_dump`/`model_validate` and handle `ValidationError` in callers
- Add pydantic dependency and update tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c27657654832cacb94c94f472d00e